### PR TITLE
Add `host` option

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,22 +62,19 @@ const getList = async () => {
 		.map(line => line.match(/\S+/g) || []);
 };
 
-module.exports.portToPid = async (arg1, arg2) => {
+module.exports.portToPid = async options => {
 	let host;
 	let port;
-	if (typeof arg1 === 'object' && arg1.port) {
-		port = arg1.port;
-		host = arg1.host;
-	} else if (typeof arg2 === 'string') {
-		port = arg1;
-		host = arg2;
-	} else if (Array.isArray(arg1)) {
-		port = arg1;
+	if (typeof options === 'object' && options.port) {
+		port = options.port;
+		host = options.host;
+	} else if (Array.isArray(options)) {
+		const ports = options;
 		const list = await getList();
-		const tuples = await Promise.all(port.map(port_ => [port_, getPort(port_, list)]));
+		const tuples = await Promise.all(ports.map(port_ => [port_, getPort(port_, list)]));
 		return new Map(tuples);
 	} else {
-		port = arg1;
+		port = options;
 	}
 
 	if (host && typeof host !== 'string') {

--- a/index.js
+++ b/index.js
@@ -88,14 +88,16 @@ module.exports.portToPid = async options => {
 	return getPort(port, await getList(), host);
 };
 
-module.exports.all = async () => {
+module.exports.all = async host => {
 	const list = await getList();
 	const returnValue = new Map();
 
 	for (const line of list) {
-		const {groups} = /[^]*[.:](?<port>\d+)$/.exec(line[addressColumn]);
+		const {groups} = /^(?<host>.*)[.:](?<port>\d+)$/.exec(line[addressColumn]);
 		if (groups) {
-			returnValue.set(Number.parseInt(groups.port, 10), parsePid(line[portColumn]));
+			if (!host || groups.host === host) {
+				returnValue.set(Number.parseInt(groups.port, 10), parsePid(line[portColumn]));
+			}
 		}
 	}
 

--- a/t-server.js
+++ b/t-server.js
@@ -1,0 +1,7 @@
+const http = require('http');
+
+const server = http.createServer().listen(process.argv[2], process.argv[3]);
+process.send({});
+process.on('SIGTERM', () => {
+	server.close();
+});

--- a/test.js
+++ b/test.js
@@ -10,7 +10,7 @@ const createServer = () => http.createServer((request, response) => {
 test('success', async t => {
 	const port = await getPort();
 	const server = createServer().listen(port);
-	t.truthy(await pidPort.portToPid(port));
+	t.is(await pidPort.portToPid(port), process.pid);
 	server.close();
 });
 
@@ -44,18 +44,10 @@ test('`.list()`', async t => {
 	await t.notThrowsAsync(pidPort.portToPid([...all.keys()]));
 });
 
-test('Node `server.listen()` signature - with different host as arg', async t => {
-	const port = await getPort();
-	const host = '127.0.0.2';
-	const server = createServer().listen(port, host);
-	t.truthy(await pidPort.portToPid(port, host));
-	server.close();
-});
-
-test('Node `server.listen()` signature - with object arg', async t => {
+test('Node `server.listen()` signature - with options object', async t => {
 	const port = await getPort();
 	const host = '127.0.0.2';
 	const server = createServer().listen({port, host});
-	t.truthy(await pidPort.portToPid({port, host}));
+	t.is(await pidPort.portToPid({port, host}), process.pid);
 	server.close();
 });

--- a/test.js
+++ b/test.js
@@ -20,7 +20,7 @@ test('fail', async t => {
 });
 
 test('accepts a number', async t => {
-	await t.throwsAsync(pidPort.portToPid('foo'), {message: 'Expected a number, got string'});
+	await t.throwsAsync(pidPort.portToPid('foo'), {message: 'Expected port to be a number, got string'});
 });
 
 test('`.all()`', async t => {
@@ -42,4 +42,20 @@ test('`.list()`', async t => {
 	const all = await pidPort.all();
 	t.true(all instanceof Map);
 	await t.notThrowsAsync(pidPort.portToPid([...all.keys()]));
+});
+
+test('Node `server.listen()` signature - with different host as arg', async t => {
+	const port = await getPort();
+	const host = '127.0.0.2';
+	const server = createServer().listen(port, host);
+	t.truthy(await pidPort.portToPid(port, host));
+	server.close();
+});
+
+test('Node `server.listen()` signature - with object arg', async t => {
+	const port = await getPort();
+	const host = '127.0.0.2';
+	const server = createServer().listen({port, host});
+	t.truthy(await pidPort.portToPid({port, host}));
+	server.close();
 });


### PR DESCRIPTION
Fixes #3. 

TODO: Update `.all()`

How should the `.all()` method be supported? 
My proposal would be that `.all()` returns a `{port}-{pid}` map for all the hosts and `.all(host)` `{port}-{pid}` map for the given host.

TODO: Update Readme with examples
