### PR TITLE
Support getting ports from a process ID

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,6 +75,34 @@ module.exports.portToPid = async port => {
 	return getPort(port, await getList());
 };
 
+module.exports.pidToPorts = async pid => {
+	if (Array.isArray(pid)) {
+		const returnValue = new Map(pid.map(pid_ => [pid_, new Set()]));
+
+		for (const [port, pid_] of await module.exports.all()) {
+			if (returnValue.has(pid_)) {
+				returnValue.get(pid_).add(port);
+			}
+		}
+
+		return returnValue;
+	}
+
+	if (!Number.isInteger(pid)) {
+		throw new TypeError(`Expected an integer, got ${typeof pid}`);
+	}
+
+	const returnValue = new Set();
+
+	for (const [port, pid_] of await module.exports.all()) {
+		if (pid_ === pid) {
+			returnValue.add(port);
+		}
+	}
+
+	return returnValue;
+};
+
 module.exports.all = async () => {
 	const list = await getList();
 	const returnValue = new Map();

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Returns a `Promise<Set<number>>` with the ports.
 
 Type: `number`
 
-Process IDs to look up.
+Process ID to look up.
 
 ### pidPort.pidToPorts(pids)
 
@@ -72,7 +72,7 @@ Returns a `Promise<Map<number, Set<number>>>` with the port as key and the proce
 
 Type: `number[]`
 
-Pids to look up.
+Process IDs to look up.
 
 ### pidPort.all()
 

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,26 @@ Type: `number[]`
 
 Ports to look up.
 
+### pidPort.pidToPorts(pid)
+
+Returns a `Promise<Set<number>>` with the ports.
+
+#### pid
+
+Type: `number`
+
+Pid to look up.
+
+### pidPort.pidToPorts(pids)
+
+Returns a `Promise<Map<number, Set<number>>>` with the port as key and the process ID as value.
+
+#### pids
+
+Type: `number[]`
+
+Pids to look up.
+
 ### pidPort.all()
 
 Get all process IDs from ports.

--- a/readme.md
+++ b/readme.md
@@ -66,7 +66,7 @@ Process ID to look up.
 
 ### pidPort.pidToPorts(pids)
 
-Returns a `Promise<Map<number, Set<number>>>` with the port as key and the process ID as value.
+Returns a `Promise<Map<number, Set<number>>>` with the process ID as the key and the ports as value.
 
 #### pids
 

--- a/readme.md
+++ b/readme.md
@@ -62,7 +62,7 @@ Returns a `Promise<Set<number>>` with the ports.
 
 Type: `number`
 
-Pid to look up.
+Process IDs to look up.
 
 ### pidPort.pidToPorts(pids)
 

--- a/test.js
+++ b/test.js
@@ -38,6 +38,22 @@ test('`.all()`', async t => {
 	server2.close();
 });
 
+test('`.pidToPorts()`', async t => {
+	const firstPort = await getPort();
+	const firstServer = createServer().listen(firstPort);
+
+	const secondPort = await getPort();
+	const secondServer = createServer().listen(secondPort);
+
+	const portsFixture = new Set([firstPort, secondPort]);
+
+	t.deepEqual(await pidPort.pidToPorts(process.pid), portsFixture);
+	t.deepEqual(await pidPort.pidToPorts([process.pid]), new Map([[process.pid, portsFixture]]));
+
+	firstServer.close();
+	secondServer.close();
+});
+
 test('`.list()`', async t => {
 	const all = await pidPort.all();
 	t.true(all instanceof Map);

--- a/test.js
+++ b/test.js
@@ -45,10 +45,19 @@ test('`.pidToPorts()`', async t => {
 	const secondPort = await getPort();
 	const secondServer = createServer().listen(secondPort);
 
-	const portsFixture = new Set([firstPort, secondPort]);
+	const portsToCheck = [firstPort, secondPort];
 
-	t.deepEqual(await pidPort.pidToPorts(process.pid), portsFixture);
-	t.deepEqual(await pidPort.pidToPorts([process.pid]), new Map([[process.pid, portsFixture]]));
+	const pidPorts = await pidPort.pidToPorts(process.pid);
+
+	for (const port of portsToCheck) {
+		t.true(pidPorts.has(port));
+	}
+
+	const pidsPorts = (await pidPort.pidToPorts([process.pid])).get(process.pid);
+
+	for (const port of portsToCheck) {
+		t.true(pidsPorts.has(port));
+	}
 
 	firstServer.close();
 	secondServer.close();


### PR DESCRIPTION
Currently returns a `Set` - should it return an array instead?

Fixes: #1 