### PR TITLE
Restore compatibility with macOS pre-Sequoia

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ const macos = async () => {
 		// txbytes before pid. Unfortunately headers can't be parsed because
 		// they're space separated but some contain spaces, so we use this
 		// heuristic to distinguish the two netstat versions.
-		pidColumn: header.indexOf('rxbytes') ? 10 : 8,
+		pidColumn: header.includes('rxbytes') ? 10 : 8,
 	};
 };
 


### PR DESCRIPTION
https://github.com/sindresorhus/pid-port/pull/12 contains a bug that would break compatibility for `netstat` versions that don't have the `rxbytes` header. This `indexOf` should've been an `includes`, otherwise the ternary obviously doesn't do what's intended.

I don't have an older macOS machine to test this on, but hopefully it's clear enough - apologies for the churn.