### PR TITLE
Update regex to work with macOS Tahoe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+.vscode

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ const parsePid = pid => {
 		return;
 	}
 
-	const {groups} = /(?:^|",|",pid=)(?<pid>\d+)/.exec(pid) || {};
+	const {groups} = /(?:^|",|",pid=|[A-z]+:)(?<pid>\d+)/.exec(pid) || {};
 	if (groups) {
 		return Number.parseInt(groups.pid, 10);
 	}


### PR DESCRIPTION
macOS Tahoe changed how the output of netstat looks (most of the lines now include `<application-name>:` before the pid. Adjusted to regex to also work with that.

Tests are all passing on my machine.

Resolves #14