### PR TITLE
Fall back to `lsof` when `ss`/`netstat` is not installed

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,29 @@ const platformImplementations = {darwin: macos, linux};
 const implementation = platformImplementations[process.platform] ?? windows;
 
 const getList = async () => {
-	const {stdout, addressColumn, pidColumn} = await implementation();
+	let result;
+	try {
+		result = await implementation();
+	} catch (error) {
+		// Primary tool (ss on Linux, netstat on macOS) not available — fall back to lsof
+		if (process.platform === 'linux' || process.platform === 'darwin') {
+			try {
+				const stdout = await lsofFallback();
+				// lsof columns: COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+				const lines = stdout
+					.split('\n')
+					.filter(line => isProtocol(line))
+					.map(line => line.match(/\S+/g) || []);
+				return {lines, addressColumn: 7, pidColumn: 1};
+			} catch {
+				// Both primary and lsof failed — rethrow original error
+			}
+		}
+
+		throw error;
+	}
+
+	const {stdout, addressColumn, pidColumn} = result;
 
 	const lines = stdout
 		.split('\n')


### PR DESCRIPTION
Fixes #18

## Problem

On Linux, `pid-port` calls `ss -tunlp` which throws if `ss` is not installed. This is common on Alpine, minimal Debian/Ubuntu containers, BusyBox-based systems, and distroless images. On macOS, `netstat` may similarly fail. The existing `lsofFallback` is only reachable when the primary tool succeeds but PID info is hidden due to permissions.

## Fix

Wrap the platform implementation (`linux()` / `macos()`) in `getList()` with try/catch. When it fails:
1. Fall back to `lsof -nP` to get port/PID info
2. Parse lsof output (COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME columns)
3. If lsof also fails, rethrow the original error

This makes the fallback reachable in all failure modes, not just the permissions case.