### PR TITLE
Fix Windows UDP ports never resolving to a PID

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,9 @@ const linux = async () => {
 
 const windows = async () => {
 	const {stdout} = await execa('netstat', ['-ano']);
-	return {stdout, addressColumn: 1, pidColumn: 4};
+	// PID column is 4 for TCP (which has a State column) and 3 for UDP (which doesn't).
+	// Starting the scan at 3 lets findPidInLine handle both.
+	return {stdout, addressColumn: 1, pidColumn: 3};
 };
 
 const isProtocol = value => /^\s*(tcp|udp)/i.test(value);
@@ -96,9 +98,9 @@ const parsePid = pid => {
 	}
 };
 
-// Search for PID starting from pidColumn, handling process names with spaces
-// When process names contain spaces (e.g., "next-server (v16.1.1)"), the ss output
-// gets split into multiple columns, so we need to search across all columns from pidColumn
+// The loop is load-bearing: it scans from pidColumn onward instead of checking a fixed index.
+// This handles Linux process names with spaces (e.g., "next-server (v16.1.1)") that shift the
+// PID column in ss output, and Windows TCP lines that have more columns than UDP lines.
 const findPidInLine = (line, pidColumn) => {
 	for (const column of line.slice(pidColumn)) {
 		const pid = parsePid(column);

--- a/test.js
+++ b/test.js
@@ -320,16 +320,18 @@ test('Linux: process names with spaces do not break PID extraction', async t => 
 });
 
 test('UDP ports resolve to a PID', async () => {
-	const port = await getPort();
 	const socket = dgram.createSocket('udp4');
 
-	try {
-		await new Promise((resolve, reject) => {
-			socket.bind(port, '127.0.0.1', error => (error ? reject(error) : resolve()));
-		});
+	await new Promise((resolve, reject) => {
+		socket.bind(0, '127.0.0.1', error => (error ? reject(error) : resolve()));
+	});
 
-		const pid = await portToPid({port, host: '127.0.0.1'});
-		assert.equal(pid, process.pid);
+	const {port} = socket.address();
+
+	try {
+		const bindings = await portBindings(port, {host: '127.0.0.1'});
+		const pids = bindings.map(b => b.pid);
+		assert.ok(pids.includes(process.pid), `Expected process ${process.pid} among bindings for UDP port ${port}, got: ${JSON.stringify(bindings)}`);
 	} finally {
 		socket.close();
 	}

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 import process from 'node:process';
+import dgram from 'node:dgram';
 import http from 'node:http';
 import {test} from 'node:test';
 import assert from 'node:assert/strict';
@@ -315,6 +316,22 @@ test('Linux: process names with spaces do not break PID extraction', async t => 
 		process.env.PATH = originalPath;
 		server?.close();
 		await fs.rm(temporaryDirectory, {recursive: true, force: true});
+	}
+});
+
+test('UDP ports resolve to a PID', async () => {
+	const port = await getPort();
+	const socket = dgram.createSocket('udp4');
+
+	try {
+		await new Promise((resolve, reject) => {
+			socket.bind(port, '127.0.0.1', error => (error ? reject(error) : resolve()));
+		});
+
+		const pid = await portToPid({port, host: '127.0.0.1'});
+		assert.equal(pid, process.pid);
+	} finally {
+		socket.close();
 	}
 });
 


### PR DESCRIPTION
Windows `netstat -ano` omits the State column for UDP lines, so they have 4 tokens instead of 5. The hardcoded `pidColumn: 4` caused `findPidInLine` to scan past the end of UDP lines. Lowering it to 3 lets the existing scan loop find the PID in both TCP and UDP rows.

Fixes #20 