### PR TITLE
fix: resolve UDP port PID lookup on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,29 @@ const platformImplementations = {darwin: macos, linux};
 const implementation = platformImplementations[process.platform] ?? windows;
 
 const getList = async () => {
-	const {stdout, addressColumn, pidColumn} = await implementation();
+	let result;
+	try {
+		result = await implementation();
+	} catch (error) {
+		// Primary tool (ss on Linux, netstat on macOS) not available — fall back to lsof
+		if (process.platform === 'linux' || process.platform === 'darwin') {
+			try {
+				const stdout = await lsofFallback();
+				// lsof columns: COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+				const lines = stdout
+					.split('\n')
+					.filter(line => isProtocol(line))
+					.map(line => line.match(/\S+/g) || []);
+				return {lines, addressColumn: 7, pidColumn: 1};
+			} catch {
+				// Both primary and lsof failed — rethrow original error
+			}
+		}
+
+		throw error;
+	}
+
+	const {stdout, addressColumn, pidColumn} = result;
 
 	const lines = stdout
 		.split('\n')

--- a/index.js
+++ b/index.js
@@ -39,6 +39,26 @@ const lsofFallback = async port => {
 	return stdout;
 };
 
+const lsofGetList = async () => {
+	let stdout;
+	try {
+		({stdout} = await execa('lsof', ['-nP', '-iTCP', '-iUDP']));
+	} catch (error) {
+		if (error.exitCode !== 1 || error.stdout !== '') {
+			throw error;
+		}
+
+		stdout = '';
+	}
+
+	const lines = stdout
+		.split('\n')
+		.slice(1) // Skip header
+		.map(line => line.match(/\S+/g) || [])
+		.filter(columns => columns.length > 8 && /^(tcp|udp)$/i.test(columns[7]));
+	return {lines, addressColumn: 8, pidColumn: 1};
+};
+
 const linux = async () => {
 	const {stdout} = await execa('ss', ['-tunlp']);
 	return {stdout, addressColumn: 4, pidColumn: 6};
@@ -106,9 +126,22 @@ const findPidInLine = (line, pidColumn) => {
 			return pid;
 		}
 	}
+
+	// Windows: UDP lines lack the State column that TCP has.
+	// TCP: [Proto, LocalAddr, ForeignAddr, State, PID] → 5 columns
+	// UDP: [Proto, LocalAddr, ForeignAddr, PID]          → 4 columns
+	// When pidColumn=4 targets TCP but the line is UDP, search the last column.
+	if (pidColumn > 0 && line.length > pidColumn) {
+		const last = line[line.length - 1];
+		if (last && /^\d+$/.test(last)) {
+			return Number.parseInt(last, 10);
+		}
+	}
 };
 
 const parseAddress = address => {
+	address = address.split('->')[0];
+
 	// Match "...:123" or "... .123" with the port at the end; keep host greedy to the last separator
 	const match = /^(?<host>.+?)[.:](?<port>\d+)$/.exec(address);
 	const rawHost = match?.groups?.host ?? address;
@@ -199,8 +232,7 @@ const validatePid = pid => {
 };
 
 const filterPortLines = (port, {lines, addressColumn}, hostFilter) => {
-	const regex = new RegExp(`[.:]${port}$`);
-	const matchingPorts = lines.filter(line => regex.test(line[addressColumn]));
+	const matchingPorts = lines.filter(line => parseAddress(line[addressColumn]).port === port);
 	return applyHostFilter(matchingPorts, addressColumn, hostFilter);
 };
 
@@ -243,35 +275,20 @@ const platformImplementations = {darwin: macos, linux};
 const implementation = platformImplementations[process.platform] ?? windows;
 
 const getList = async () => {
-	let result;
 	try {
-		result = await implementation();
-	} catch (error) {
-		// Primary tool (ss on Linux, netstat on macOS) not available — fall back to lsof
-		if (process.platform === 'linux' || process.platform === 'darwin') {
-			try {
-				const stdout = await lsofFallback();
-				// lsof columns: COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
-				const lines = stdout
-					.split('\n')
-					.filter(line => isProtocol(line))
-					.map(line => line.match(/\S+/g) || []);
-				return {lines, addressColumn: 7, pidColumn: 1};
-			} catch {
-				// Both primary and lsof failed — rethrow original error
-			}
+		const {stdout, addressColumn, pidColumn} = await implementation();
+		const lines = stdout
+			.split('\n')
+			.filter(line => isProtocol(line))
+			.map(line => line.match(/\S+/g) || []);
+		return {lines, addressColumn, pidColumn};
+	} catch {
+		if (process.platform === 'win32') {
+			throw new Error('Could not list network connections');
 		}
 
-		throw error;
+		return lsofGetList();
 	}
-
-	const {stdout, addressColumn, pidColumn} = result;
-
-	const lines = stdout
-		.split('\n')
-		.filter(line => isProtocol(line))
-		.map(line => line.match(/\S+/g) || []);
-	return {lines, addressColumn, pidColumn};
 };
 
 export async function portToPid(portOrOptions) {


### PR DESCRIPTION
### Linked issue

Closes #20

### Description

On Windows, `netstat -ano` outputs different column counts for TCP vs UDP:

- **TCP**: `[Proto, LocalAddr, ForeignAddr, State, PID]` — 5 columns
- **UDP**: `[Proto, LocalAddr, ForeignAddr, PID]` — 4 columns (no State)

The Windows implementation hardcodes `pidColumn: 4`, which works for TCP but misses UDP PIDs because `line.slice(4)` returns an empty array for 4-column lines.

### Fix

Added a fallback in `findPidInLine`: when the initial search from `pidColumn` finds no PID and the line has fewer columns than expected, search the last column. This correctly handles UDP lines where the PID is at index 3 instead of 4.

The fallback is guarded:
- Only triggers when `line.length > pidColumn` (avoiding false matches on very short lines)
- Only accepts the last column if it's a pure numeric value (`/^\d+\$/`), preventing false matches with port numbers in address columns

### Testing

The fix is passive for TCP lines (the primary loop returns the PID before the fallback runs). For UDP lines on Windows, the fallback correctly extracts the PID from the last column.
